### PR TITLE
Add Advanced Mapping script and README for Unicode workaround

### DIFF
--- a/advanced-mapping/README.md
+++ b/advanced-mapping/README.md
@@ -1,0 +1,33 @@
+# Unicode Workaround in CluedIn Advanced Mapping
+
+## Overview
+
+This script detects blank string fields in incoming data and replaces them with the Unicode zero-width space character (`\u200B`).
+
+This prevents ingestion issues that may occur when sending completely empty strings through CluedIn pipelines.
+
+## Script File
+
+- `unicode-replace-empty.js`
+
+## How it Works
+
+The JavaScript scans all properties in the `input` object.  
+If a property's value is a string and is blank (like `""` or `"   "`), it replaces it with `\u200B`.
+
+## Example
+
+**Input:**
+```json
+{
+  "FirstName": "Tim",
+  "MiddleName": "",
+  "LastName": "Ward"
+}
+**Output:**
+```json
+{
+  "FirstName": "Tim",
+  "MiddleName": "\u200B",
+  "LastName": "Ward"
+}

--- a/advanced-mapping/README.md
+++ b/advanced-mapping/README.md
@@ -24,8 +24,8 @@ If a property's value is a string and is blank (like `""` or `"   "`), it replac
   "MiddleName": "",
   "LastName": "Ward"
 }
-**Output:**
 
+**Output:**
 ```json
 {
   "FirstName": "Tim",

--- a/advanced-mapping/README.md
+++ b/advanced-mapping/README.md
@@ -18,18 +18,22 @@ If a property's value is a string and is blank (like `""` or `"   "`), it replac
 ## Example
 
 **Input:**
+
 ```json
 {
   "FirstName": "Tim",
   "MiddleName": "",
   "LastName": "Ward"
 }
+Output:
 
-**Output:**
 ```json
+
 {
   "FirstName": "Tim",
   "MiddleName": "\u200B",
   "LastName": "Ward"
 }
+
+
 

--- a/advanced-mapping/README.md
+++ b/advanced-mapping/README.md
@@ -25,7 +25,9 @@ If a property's value is a string and is blank (like `""` or `"   "`), it replac
   "MiddleName": "",
   "LastName": "Ward"
 }
-`**Output:**`
+```
+
+**Output:**
 
 ```json
 {
@@ -33,6 +35,8 @@ If a property's value is a string and is blank (like `""` or `"   "`), it replac
   "MiddleName": "\u200B",
   "LastName": "Ward"
 }
+```
+
 
 
 

--- a/advanced-mapping/README.md
+++ b/advanced-mapping/README.md
@@ -25,6 +25,7 @@ If a property's value is a string and is blank (like `""` or `"   "`), it replac
   "LastName": "Ward"
 }
 **Output:**
+
 ```json
 {
   "FirstName": "Tim",

--- a/advanced-mapping/README.md
+++ b/advanced-mapping/README.md
@@ -25,7 +25,7 @@ If a property's value is a string and is blank (like `""` or `"   "`), it replac
   "MiddleName": "",
   "LastName": "Ward"
 }
-**Output:**
+`**Output:**`
 
 ```json
 {

--- a/advanced-mapping/README.md
+++ b/advanced-mapping/README.md
@@ -25,15 +25,15 @@ If a property's value is a string and is blank (like `""` or `"   "`), it replac
   "MiddleName": "",
   "LastName": "Ward"
 }
-Output:
+**Output:**
 
 ```json
-
 {
   "FirstName": "Tim",
   "MiddleName": "\u200B",
   "LastName": "Ward"
 }
+
 
 
 

--- a/advanced-mapping/README.md
+++ b/advanced-mapping/README.md
@@ -32,3 +32,4 @@ If a property's value is a string and is blank (like `""` or `"   "`), it replac
   "MiddleName": "\u200B",
   "LastName": "Ward"
 }
+

--- a/advanced-mapping/unicode-replace-empty.js
+++ b/advanced-mapping/unicode-replace-empty.js
@@ -1,0 +1,14 @@
+function transform(input, context) {
+    const ZERO_WIDTH_SPACE = "\u200B";
+
+    for (const key in input) {
+        if (input.hasOwnProperty(key)) {
+            const value = input[key];
+            if (typeof value === "string" && value.trim() === "") {
+                input[key] = ZERO_WIDTH_SPACE;
+            }
+        }
+    }
+
+    return input;
+}


### PR DESCRIPTION
## Description

This PR adds a new JavaScript script (`unicode-replace-empty.js`) to the `advanced-mapping` folder. The script replaces empty string values with the Unicode zero-width space character (`\u200B`) to prevent ingestion issues in CluedIn.

It also includes a `README.md` file with a detailed explanation, sample input/output, and usage notes.

## How has it been tested?

Manually reviewed formatting and structure in GitHub UI. Logic aligns with the expected Advanced Mapping behaviour.

## Notable Changes

- `advanced-mapping/unicode-replace-empty.js` - JavaScript logic to insert Unicode in empty strings.
- `advanced-mapping/README.md` - Documentation with an example.
